### PR TITLE
--check-joins options for ndjson-join

### DIFF
--- a/ndjson-join
+++ b/ndjson-join
@@ -13,6 +13,7 @@ commander
     .usage("[options] [expression₀ [expression₁]] <file₀> <file₁>")
     .description("Join two newline-delimited JSON streams into a stream of pairs.")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
+    .option("-a, --all-rows", "requires at least a join per row")
     .parse(process.argv);
 
 if (commander.args.length < 2 || commander.args.length > 4) {
@@ -77,6 +78,30 @@ readline.createInterface({
 });
 
 function join() {
+
+  if(commander.allRows){
+    var missingKeys = [];
+    map.forEach(function(value, key) {
+      value[0].forEach(function(v0) {
+        if(value[1].length == 0){
+          missingKeys.push({key:key, record:v0})
+        }
+      })
+    });
+
+    if(missingKeys.length){
+      missingKeys.map(function(k){
+        console.error("Error: cannot join any record with:")
+        console.error("key:", k.key)
+        console.error("record:\n", k.record)
+
+      });
+      console.error("\nError: --all-rows options was specified and no joinable row were found.")
+      process.exit(1);
+    }
+
+  }
+
   map.forEach(function(value, key) {
     value[0].forEach(function(v0) {
       value[1].forEach(function(v1) {

--- a/ndjson-join
+++ b/ndjson-join
@@ -13,7 +13,7 @@ commander
     .usage("[options] [expression₀ [expression₁]] <file₀> <file₁>")
     .description("Join two newline-delimited JSON streams into a stream of pairs.")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
-    .option("-a, --all-rows", "requires at least a join per row")
+    .option("-c, --check-joins", "emits a warning for records in the first stream with no match")
     .parse(process.argv);
 
 if (commander.args.length < 2 || commander.args.length > 4) {
@@ -79,7 +79,7 @@ readline.createInterface({
 
 function join() {
 
-  if(commander.allRows){
+  if(commander.checkJoins){
     var missingKeys = [];
     map.forEach(function(value, key) {
       value[0].forEach(function(v0) {
@@ -91,13 +91,12 @@ function join() {
 
     if(missingKeys.length){
       missingKeys.map(function(k){
-        console.error("Error: cannot join any record with:")
-        console.error("key:", k.key)
-        console.error("record:\n", k.record)
+        console.warn("\nWarning: cannot join any record with:")
+        console.warn("key:", k.key)
+        console.warn("record:\n", k.record)
 
       });
-      console.error("\nError: --all-rows options was specified and no joinable row were found.")
-      process.exit(1);
+      console.error("\nWarning: --check-joins options was specified but no joinable rows were found.");
     }
 
   }


### PR DESCRIPTION
This is a possible fix for #14, as it adds a `--check-joins` option that warns about each record in the LHS stream that has no match with the RHS one.