### PR TITLE
Add support for left and right joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ ndjson-join 'd.name' <(csv2json -n a.csv) <(csv2json -n b.csv) | ndjson-map 'Obj
 <a name="ndjson_join_right" href="ndjson_join_right">#</a> ndjson-join <b>--right</b><br>
 <a name="ndjson_join_outer" href="ndjson_join_outer">#</a> ndjson-join <b>--outer</b><br>
 
-Specify the type of join (either [left](https://en.wikipedia.org/wiki/Join_\(SQL\)#Left_outer_join), [right](https://en.wikipedia.org/wiki/Join_\(SQL\)#Right_outer_join), [outer](https://en.wikipedia.org/wiki/Join_\(SQL\)#Full_outer_join)). Defaults to an [inner join]((https://en.wikipedia.org/wiki/Join_\(SQL\)#Inner_join))
+Specify the type of join (either [left](https://en.wikipedia.org/wiki/Join_\(SQL\)#Left_outer_join), [right](https://en.wikipedia.org/wiki/Join_\(SQL\)#Right_outer_join), [outer](https://en.wikipedia.org/wiki/Join_\(SQL\)#Full_outer_join)). Empty values are output as `null`. Defaults to an [inner join]((https://en.wikipedia.org/wiki/Join_\(SQL\)#Inner_join))
 
 ### sort
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ To consolidate the results into a single object, use [ndjson-map](#ndjson-map) a
 ndjson-join 'd.name' <(csv2json -n a.csv) <(csv2json -n b.csv) | ndjson-map 'Object.assign(d[0], d[1])'
 ```
 
+<a name="ndjson_join_left" href="ndjson_join_left">#</a> ndjson-join <b>--left</b><br>
+<a name="ndjson_join_right" href="ndjson_join_right">#</a> ndjson-join <b>--right</b><br>
+<a name="ndjson_join_outer" href="ndjson_join_outer">#</a> ndjson-join <b>--outer</b><br>
+
+Specify the type of join (either [left](https://en.wikipedia.org/wiki/Join_\(SQL\)#Left_outer_join), [right](https://en.wikipedia.org/wiki/Join_\(SQL\)#Right_outer_join), [outer](https://en.wikipedia.org/wiki/Join_\(SQL\)#Full_outer_join)). Defaults to an [inner join]((https://en.wikipedia.org/wiki/Join_\(SQL\)#Inner_join))
+
 ### sort
 
 <a name="ndjson_sort" href="#ndjson_sort">#</a> <b>ndjson-sort</b> [<i>expression</i>] [<>](https://github.com/mbostock/ndjson-cli/blob/master/ndjson-sort "Source")

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ ndjson-join 'd.name' <(csv2json -n a.csv) <(csv2json -n b.csv) | ndjson-map 'Obj
 <a name="ndjson_join_right" href="ndjson_join_right">#</a> ndjson-join <b>--right</b><br>
 <a name="ndjson_join_outer" href="ndjson_join_outer">#</a> ndjson-join <b>--outer</b><br>
 
-Specify the type of join (either [left](https://en.wikipedia.org/wiki/Join_\(SQL\)#Left_outer_join), [right](https://en.wikipedia.org/wiki/Join_\(SQL\)#Right_outer_join), [outer](https://en.wikipedia.org/wiki/Join_\(SQL\)#Full_outer_join)). Empty values are output as `null`. Defaults to an [inner join]((https://en.wikipedia.org/wiki/Join_\(SQL\)#Inner_join))
+Specify the type of join: [left](https://en.wikipedia.org/wiki/Join_\(SQL\)#Left_outer_join), [right](https://en.wikipedia.org/wiki/Join_\(SQL\)#Right_outer_join), or [outer](https://en.wikipedia.org/wiki/Join_\(SQL\)#Full_outer_join)). Empty values are output as `null`. If none of these arguments are specified, defaults to [inner](https://en.wikipedia.org/wiki/Join_\(SQL\)#Inner_join).
 
 ### sort
 

--- a/ndjson-join
+++ b/ndjson-join
@@ -13,6 +13,8 @@ commander
     .usage("[options] [expression₀ [expression₁]] <file₀> <file₁>")
     .description("Join two newline-delimited JSON streams into a stream of pairs.")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
+    .option("--left", "Perform a left join", false)
+    .option("--right", "Perform a right join", false)
     .parse(process.argv);
 
 if (commander.args.length < 2 || commander.args.length > 4) {
@@ -24,6 +26,8 @@ if (commander.args.length < 4) {
   if (commander.args.length < 3) commander.args.splice(0, 0, "i");
   commander.args.splice(1, 0, commander.args[0]);
 }
+
+var join = commander.left ? leftJoin : commander.right ? rightJoin : innerJoin;
 
 var i0 = -1,
     i1 = -1,
@@ -76,12 +80,40 @@ readline.createInterface({
   if ((ii |= 2) === 3) join();
 });
 
-function join() {
+function innerJoin() {
   map.forEach(function(value, key) {
     value[0].forEach(function(v0) {
       value[1].forEach(function(v1) {
         output([v0, v1]);
       });
+    });
+  });
+}
+
+function leftJoin() {
+  map.forEach(function(value, key) {
+    value[0].forEach(function(v0) {
+      if (value[1].length === 0) {
+        output([v0, null])
+      } else {
+        value[1].forEach(function(v1) {
+          output([v0, v1]);
+        });
+      }
+    });
+  });
+}
+
+function rightJoin() {
+  map.forEach(function(value, key) {
+    value[1].forEach(function(v1) {
+      if (value[0].length === 0) {
+        output([null, v1])
+      } else {
+        value[0].forEach(function(v0) {
+          output([v0, v1]);
+        });
+      }
     });
   });
 }

--- a/ndjson-join
+++ b/ndjson-join
@@ -28,6 +28,13 @@ if (commander.args.length < 4) {
   commander.args.splice(1, 0, commander.args[0]);
 }
 
+if ([commander.left, commander.right, commander.outer].filter(Boolean).length > 1) {
+  console.error();
+  console.error("  error: only one of --left, --right, --outer allowed")
+  console.error();
+  process.exit(1);
+}
+
 var join = commander.left ? leftJoin : commander.right ? rightJoin : commander.outer ? outerJoin : innerJoin;
 
 var i0 = -1,

--- a/ndjson-join
+++ b/ndjson-join
@@ -93,12 +93,12 @@ function innerJoin() {
 function leftJoin() {
   map.forEach(function(value, key) {
     value[0].forEach(function(v0) {
-      if (value[1].length === 0) {
-        output([v0, null])
-      } else {
+      if (value[1].length) {
         value[1].forEach(function(v1) {
           output([v0, v1]);
         });
+      } else {
+        output([v0, null]);
       }
     });
   });
@@ -108,11 +108,11 @@ function rightJoin() {
   map.forEach(function(value, key) {
     value[1].forEach(function(v1) {
       if (value[0].length === 0) {
-        output([null, v1])
-      } else {
         value[0].forEach(function(v0) {
           output([v0, v1]);
         });
+      } else {
+        output([null, v1]);
       }
     });
   });

--- a/ndjson-join
+++ b/ndjson-join
@@ -13,8 +13,9 @@ commander
     .usage("[options] [expression₀ [expression₁]] <file₀> <file₁>")
     .description("Join two newline-delimited JSON streams into a stream of pairs.")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
-    .option("--left", "Perform a left join", false)
-    .option("--right", "Perform a right join", false)
+    .option("--left", "perform a left join", false)
+    .option("--right", "perform a right join", false)
+    .option("--outer", "perform an outer join", false)
     .parse(process.argv);
 
 if (commander.args.length < 2 || commander.args.length > 4) {
@@ -27,7 +28,7 @@ if (commander.args.length < 4) {
   commander.args.splice(1, 0, commander.args[0]);
 }
 
-var join = commander.left ? leftJoin : commander.right ? rightJoin : innerJoin;
+var join = commander.left ? leftJoin : commander.right ? rightJoin : commander.outer ? outerJoin : innerJoin;
 
 var i0 = -1,
     i1 = -1,
@@ -91,29 +92,44 @@ function innerJoin() {
 }
 
 function leftJoin() {
-  map.forEach(function(value, key) {
-    value[0].forEach(function(v0) {
-      if (value[1].length) {
-        value[1].forEach(function(v1) {
-          output([v0, v1]);
-        });
-      } else {
-        output([v0, null]);
-      }
-    });
-  });
+  map.forEach(leftJoinValue);
 }
 
 function rightJoin() {
+  map.forEach(rightJoinValue);
+}
+
+
+function outerJoin() {
   map.forEach(function(value, key) {
-    value[1].forEach(function(v1) {
-      if (value[0].length === 0) {
-        value[0].forEach(function(v0) {
-          output([v0, v1]);
-        });
-      } else {
-        output([null, v1]);
-      }
-    });
+    if (value[0].length) {
+      leftJoinValue(value, key);
+    } else if (value[1].length) {
+      rightJoinValue(value, key);
+    }
+  });
+}
+
+function leftJoinValue(value, key) {
+  value[0].forEach(function(v0) {
+    if (value[1].length) {
+      value[1].forEach(function(v1) {
+        output([v0, v1]);
+      });
+    } else {
+      output([v0, null]);
+    }
+  });
+}
+
+function rightJoinValue(value, key) {
+  value[1].forEach(function(v1) {
+    if (value[0].length) {
+      value[0].forEach(function(v0) {
+        output([v0, v1]);
+      });
+    } else {
+      output([null, v1]);
+    }
   });
 }

--- a/ndjson-join
+++ b/ndjson-join
@@ -35,7 +35,10 @@ if ([commander.left, commander.right, commander.outer].filter(Boolean).length > 
   process.exit(1);
 }
 
-var join = commander.left ? leftJoin : commander.right ? rightJoin : commander.outer ? outerJoin : innerJoin;
+var join = commander.left ? joinLeft
+    : commander.right ? joinRight
+    : commander.outer ? joinOuter
+    : joinInner;
 
 var i0 = -1,
     i1 = -1,
@@ -88,7 +91,7 @@ readline.createInterface({
   if ((ii |= 2) === 3) join();
 });
 
-function innerJoin() {
+function joinInner() {
   map.forEach(function(value, key) {
     value[0].forEach(function(v0) {
       value[1].forEach(function(v1) {
@@ -98,26 +101,22 @@ function innerJoin() {
   });
 }
 
-function leftJoin() {
-  map.forEach(leftJoinValue);
+function joinLeft() {
+  map.forEach(joinLeftValue);
 }
 
-function rightJoin() {
-  map.forEach(rightJoinValue);
+function joinRight() {
+  map.forEach(joinRightValue);
 }
 
-
-function outerJoin() {
+function joinOuter() {
   map.forEach(function(value, key) {
-    if (value[0].length) {
-      leftJoinValue(value, key);
-    } else if (value[1].length) {
-      rightJoinValue(value, key);
-    }
+    if (value[0].length) joinLeftValue(value, key);
+    else if (value[1].length) joinRightValue(value, key);
   });
 }
 
-function leftJoinValue(value, key) {
+function joinLeftValue(value, key) {
   value[0].forEach(function(v0) {
     if (value[1].length) {
       value[1].forEach(function(v1) {
@@ -129,7 +128,7 @@ function leftJoinValue(value, key) {
   });
 }
 
-function rightJoinValue(value, key) {
+function joinRightValue(value, key) {
   value[1].forEach(function(v1) {
     if (value[0].length) {
       value[0].forEach(function(v0) {

--- a/test/c.csv
+++ b/test/c.csv
@@ -1,2 +1,3 @@
 name,number
 Fred,42
+Barney,34

--- a/test/c.csv
+++ b/test/c.csv
@@ -1,0 +1,2 @@
+name,number
+Fred,42


### PR DESCRIPTION
Fixes #21.

I also added a new test file. The results are the following:

```sh
# Left
./ndjson-join 'd.name' <(csv2json -n test/a.csv) <(csv2json -n test/c.csv) --left
[{"name":"Fred","color":"red"},{"name":"Fred","number":"42"}]
[{"name":"Alice","color":"green"},null]
[{"name":"Bob","color":"blue"},null]

# Right
./ndjson-join 'd.name' <(csv2json -n test/c.csv) <(csv2json -n test/a.csv) --right
[{"name":"Fred","number":"42"},{"name":"Fred","color":"red"}]
[null,{"name":"Alice","color":"green"}]
[null,{"name":"Bob","color":"blue"}]

# Inner (default)
./ndjson-join 'd.name' <(csv2json -n test/a.csv) <(csv2json -n test/c.csv)
[{"name":"Fred","color":"red"},{"name":"Fred","number":"42"}]
```