### PR TITLE
Document variables provided to expressions in CLI help.

### DIFF
--- a/ndjson-filter
+++ b/ndjson-filter
@@ -10,7 +10,8 @@ var readline = require("readline"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression]")
-    .description("Filter values in a newline-delimited JSON stream.")
+    .description("Filter values in a newline-delimited JSON stream." +
+      "\n\n  expression: JavaScript expression where 'd' is row value, 'i' is row index")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
     .parse(process.argv);
 

--- a/ndjson-join
+++ b/ndjson-join
@@ -11,7 +11,9 @@ var fs = require("fs"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression₀ [expression₁]] <file₀> <file₁>")
-    .description("Join two newline-delimited JSON streams into a stream of pairs.")
+    .description("Join two newline-delimited JSON streams into a stream of pairs." +
+      "\n\n  expression₀: JavaScript join expression for left stream. 'd': row value, 'i': row index (defaults to 'i')" +
+      "\n  expression₁: JavaScript join expression for right stream. 'd': row value, 'i': row index (defaults to 'expression₀')")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
     .option("--left", "perform a left join", false)
     .option("--right", "perform a right join", false)

--- a/ndjson-map
+++ b/ndjson-map
@@ -10,7 +10,8 @@ var readline = require("readline"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression]")
-    .description("Transform values in a newline-delimited JSON stream.")
+    .description("Transform values in a newline-delimited JSON stream." +
+      "\n\n  expression: JavaScript map expression. 'd': row value, 'i': row index")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
     .parse(process.argv);
 

--- a/ndjson-reduce
+++ b/ndjson-reduce
@@ -10,7 +10,9 @@ var readline = require("readline"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression [initial]]")
-    .description("Reduce a newline-delimited JSON stream to a single value.")
+    .description("Reduce a newline-delimited JSON stream to a single value." +
+      "\n\n  expression: JavaScript expression where 'd' is row value, 'i' is row index, 'p' is accumulator" +
+        "\n  initial: JavaScript expression for initial value of accumulator. Defaults to 'd'")
     .option("-r, --require <name=module>", "require a module", requires, {p: undefined, d: undefined, i: -1})
     .parse(process.argv);
 

--- a/ndjson-sort
+++ b/ndjson-sort
@@ -10,7 +10,8 @@ var readline = require("readline"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression]")
-    .description("Sort values in a newline-delimited JSON stream.")
+    .description("Sort values in a newline-delimited JSON stream." +
+      "\n\n  expression: JavaScript expression returning integer, where 'a' and 'b' are row values to compare.")
     .option("-r, --require <name=module>", "require a module", requires, {a: undefined, b: undefined})
     .parse(process.argv);
 

--- a/ndjson-split
+++ b/ndjson-split
@@ -10,7 +10,8 @@ var readline = require("readline"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression]")
-    .description("Transform values in a newline-delimited JSON stream into multiple values.")
+    .description("Transform values in a newline-delimited JSON stream into multiple values." +
+      "\n\n  expression: JavaScript expression where 'd' is row value, 'i' is row index")
     .option("-r, --require <name=module>", "require a module", requires, {d: undefined, i: -1})
     .parse(process.argv);
 

--- a/ndjson-top
+++ b/ndjson-top
@@ -10,7 +10,8 @@ var readline = require("readline"),
 commander
     .version(require("./package.json").version)
     .usage("[options] [expression]")
-    .description("Select the top values from a newline-delimited JSON stream.")
+    .description("Select the top values from a newline-delimited JSON stream." +
+      "\n\n  expression: JavaScript expression returning integer, where 'a' and 'b' are row values to compare.")
     .option("-n <value>", "the maximum number of output values", 1)
     .option("-r, --require <name=module>", "require a module", requires, {a: undefined, b: undefined})
     .parse(process.argv);


### PR DESCRIPTION
Currently the only way to know what variables are provided to the CLI expressions is to look up the web documentation. This PR gives a very brief description of each variable in the CLI help.